### PR TITLE
Correcting the spelling - GoogleTranslateWithoutApiKey.properties

### DIFF
--- a/src/main/resources/GoogleTranslateWithoutApiKey.properties
+++ b/src/main/resources/GoogleTranslateWithoutApiKey.properties
@@ -1,1 +1,1 @@
-GoogleTranslateNoAPI=Google Translate (witout API key)
+GoogleTranslateNoAPI=Google Translate (without API key)


### PR DESCRIPTION
Below the translation, there is "<Google Translate (witout API key)> displayed. This should be "<Google Translate (without API key)>", with a "h" in without!